### PR TITLE
Fix broken .env logic.

### DIFF
--- a/S3MP/_version.py
+++ b/S3MP/_version.py
@@ -1,3 +1,3 @@
 """Semantic versioning for S3MP."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/S3MP/global_config.py
+++ b/S3MP/global_config.py
@@ -7,13 +7,9 @@ import boto3
 from S3MP.types import S3Client, S3Resource, S3Bucket, S3TransferConfig
 
 def get_env_file_path() -> Path:
-    """Get the mirror root from .env file."""
-    root_module_folder = Path(__file__).parent.parent.resolve()
-    env_file = root_module_folder / ".env"
-    if not env_file.exists():
-        raise FileNotFoundError("No .env file found.")
-
-    return env_file
+    """Get the location of the .env file."""
+    root_module_folder = Path(__file__).parent.resolve()
+    return root_module_folder / ".env"
 
 def set_env_mirror_root(mirror_root: Path) -> None:
     """Set the mirror root in the .env file."""
@@ -26,14 +22,14 @@ def get_env_mirror_root() -> Path:
     """Get the mirror root from .env file."""
     if S3MPConfig.mirror_root is not None:
         return Path(S3MPConfig.mirror_root)
+    env_file_path = get_env_file_path()
     try:
-        env_file = get_env_file_path()
+        with open(f"{env_file_path}", "r") as f:
+            mirror_root = f.read().strip().replace("MIRROR_ROOT=", "")
     except FileNotFoundError:
         print("No .env file found, using temporary directory as mirror root.")
         return Path(tempfile.gettempdir())
         
-    with open(f"{env_file}", "r") as f:
-        mirror_root = f.read().strip().replace("MIRROR_ROOT=", "")
 
     return Path(mirror_root)
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "S3MP"
-version = "0.4.1"
+version = "0.4.2"
 description = ""
 authors = [
     {name = "Joshua Dean", email = "joshua.dean@sentera.com"}


### PR DESCRIPTION
# Fix broken `.env` logic
## What?
Change function to only return `.env` file path and move error handle around the read of the path rather than the path getter.
## Checks:
- [X] Merged latest master
- [X] Updated README.md (if needed)
- [X] Changed version number in `S3MP/_version.py` and `pyproject.toml`
- [X] Packages match in `environment.yml` and `pyproject.toml`