### PR TITLE
Fix/period in folder

### DIFF
--- a/S3MP/_version.py
+++ b/S3MP/_version.py
@@ -1,3 +1,3 @@
 """Semantic versioning for S3MP."""
 
-__version__ = "0.5.4"
+__version__ = "0.6.0"

--- a/S3MP/_version.py
+++ b/S3MP/_version.py
@@ -1,3 +1,3 @@
 """Semantic versioning for S3MP."""
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"

--- a/S3MP/mirror_path.py
+++ b/S3MP/mirror_path.py
@@ -155,28 +155,7 @@ class MirrorPath:
 
     def get_children_on_s3(self) -> List[MirrorPath]:
         """Get all children on s3."""
-        child_s3_keys = []
-        continuation_token = None
-
-        while True:
-            resp = s3_list_child_keys(
-                self.s3_key, continuation_token=continuation_token
-            )
-
-            # Collect keys from the current response
-            if "Contents" in resp:
-                child_s3_keys.extend(
-                    obj["Key"] for obj in resp["Contents"] if obj["Key"] != self.s3_key
-                )
-            if "CommonPrefixes" in resp:
-                child_s3_keys.extend(obj["Prefix"] for obj in resp["CommonPrefixes"])
-
-            # Check if there are more pages to fetch
-            if "NextContinuationToken" in resp:
-                continuation_token = resp["NextContinuationToken"]
-            else:
-                break
-        return [MirrorPath.from_s3_key(key) for key in child_s3_keys]
+        return [MirrorPath.from_s3_key(key) for key in s3_list_child_keys(self.s3_key)]
 
     def get_parent(self) -> MirrorPath:
         """Get the parent of this file."""

--- a/S3MP/mirror_path.py
+++ b/S3MP/mirror_path.py
@@ -90,6 +90,10 @@ class MirrorPath:
         """Check if is a file on s3."""
         return key_is_file_on_s3(self.s3_key)
     
+    def is_file_and_exists_on_s3(self) -> bool:
+        """Check if is a file and exists on s3."""
+        return self.exists_on_s3() and self.is_file_on_s3()
+    
     def update_callback_on_skipped_transfer(self):
         """Update the current global callback if the transfer gets skipped."""
         if S3MPConfig.callback and self in S3MPConfig.callback._transfer_objs:

--- a/S3MP/mirror_path.py
+++ b/S3MP/mirror_path.py
@@ -37,7 +37,11 @@ class MirrorPath:
         """Get s3 key."""
         ret_key = "/".join([str(s.name) for s in self.key_segments])
         # We'll infer folder/file based on extension
-        return ret_key if '.' in self.key_segments[-1].name else f"{ret_key}/"
+        # HACK to catch case where the "extension" is actually a part of the folder name
+        # (eg, a folder named "v0.1.0"), we check if the extension is actually a number
+        name = self.key_segments[-1].name
+        ext = name.split('.')[-1]
+        return ret_key if (ext is not name and not ext.isdigit()) else f"{ret_key}/"
     
     @property
     def local_path(self) -> Path:

--- a/S3MP/utils/s3_utils.py
+++ b/S3MP/utils/s3_utils.py
@@ -118,7 +118,7 @@ def key_is_file_on_s3(
         client.head_object(Bucket=bucket.name, Key=key)
         return True
     except Exception as e:
-        # 404 occurs is the key is a "folder" or does not exist
+        # 404 occurs if the key is a "folder" or does not exist
         if "404" in str(e):
             return False
         else:

--- a/S3MP/utils/s3_utils.py
+++ b/S3MP/utils/s3_utils.py
@@ -111,7 +111,7 @@ def key_is_file_on_s3(
     client = client or S3MPConfig.s3_client
 
     try:
-        client.head_object(Bucket=bucket, Key=key)
+        client.head_object(Bucket=bucket.name, Key=key)
         return True
     except ClientError as e:
         if e.response['Error']['Code'] == '404':

--- a/S3MP/utils/s3_utils.py
+++ b/S3MP/utils/s3_utils.py
@@ -66,6 +66,7 @@ def download_key(
     """Download a key from S3."""
     bucket = bucket or S3MPConfig.bucket
     client = client or S3MPConfig.s3_client
+    print(f"{key} is file: {key_is_file_on_s3(key, bucket, client)}")
     if key_is_file_on_s3(key, bucket, client):
         local_path.parent.mkdir(parents=True, exist_ok=True)
         client.download_file(bucket.name, key, str(local_path), Callback=S3MPConfig.callback, Config=S3MPConfig.transfer_config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "S3MP"
-version = "0.5.3"
+version = "0.5.4"
 description = ""
 authors = [
     {name = "Joshua Dean", email = "joshua.dean@sentera.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "S3MP"
-version = "0.5.4"
+version = "0.6.0"
 description = ""
 authors = [
     {name = "Joshua Dean", email = "joshua.dean@sentera.com"}


### PR DESCRIPTION
- Catch specific use case where periods are used in a folder to represent a number and not a file extension (eg v0.1.2)
- Rework of `is_file_on_s3` util to use `head_object` which seems to be more consistent. This does change behavior of that function to not raise an exception if the key is not found, since the 404 error can also just mean that the key is not a valid file (read: its a folder). Instead, users should use a combination of `exists_on_s3` and `is_file_on_s3` to properly handle all cases.
- Moved continuation logic to `s3_utils` instead of `mirror_path`